### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/costay/01549d5f-4789-4400-8a4b-d9722c96c854/a8e2a526-edf8-4de3-bdfe-49c2a708e569/_apis/work/boardbadge/ef63341c-144f-4888-aadf-cd5a97b75892)](https://dev.azure.com/costay/01549d5f-4789-4400-8a4b-d9722c96c854/_boards/board/t/a8e2a526-edf8-4de3-bdfe-49c2a708e569/Microsoft.RequirementCategory)
 # cloudshell-shell-connectivity-flow
 [![Build status](https://travis-ci.org/QualiSystems/cloudshell-shell-connectivity-flow.svg?branch=dev)](https://travis-ci.org/QualiSystems/cloudshell-shell-connectivity-flow)
 [![codecov](https://codecov.io/gh/QualiSystems/cloudshell-shell-connectivity-flow/branch/dev/graph/badge.svg)](https://codecov.io/gh/QualiSystems/cloudshell-shell-connectivity-flow)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/costay/01549d5f-4789-4400-8a4b-d9722c96c854/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.